### PR TITLE
Add patch to update mavlink-router service

### DIFF
--- a/aero-mavlink-router/aero-mavlink-router_1.0/debian/changelog
+++ b/aero-mavlink-router/aero-mavlink-router_1.0/debian/changelog
@@ -1,3 +1,9 @@
+mavlink-router (1.0-2) unstable; urgency=medium
+
+  * Incremental release with workaround to reduce the corruption seen on ttyS1
+
+ -- Avinash Reddy Palleti <avinash.reddy.palleti@intel.com>  Fri, 10 Nov 2017 22:14:17 +0530
+
 mavlink-router (1.0-1) unstable; urgency=medium
 
   * Initial release

--- a/aero-mavlink-router/aero-mavlink-router_1.0/debian/patches/add-ttyS1-workaround.patch
+++ b/aero-mavlink-router/aero-mavlink-router_1.0/debian/patches/add-ttyS1-workaround.patch
@@ -1,0 +1,12 @@
+Index: aero-mavlink-router_1.0/mavlink-router.service.in
+===================================================================
+--- aero-mavlink-router_1.0.orig/mavlink-router.service.in
++++ aero-mavlink-router_1.0/mavlink-router.service.in
+@@ -3,6 +3,7 @@ Description=MAVLink Router
+ 
+ [Service]
+ Type=simple
++ExecStartPre=/bin/bash -c 'echo 4 > /sys/class/tty/ttyS1/rx_trig_bytes'
+ ExecStart=@bindir@/mavlink-routerd
+ Restart=on-failure
+ 

--- a/aero-mavlink-router/aero-mavlink-router_1.0/debian/patches/series
+++ b/aero-mavlink-router/aero-mavlink-router_1.0/debian/patches/series
@@ -1,0 +1,1 @@
+add-ttyS1-workaround.patch


### PR DESCRIPTION
Updating mavlink-router service to add workaround for corruption seen on ttyS1
on Aero for the  default value (8). This means we get higher interrupt rates,
but the corruption is much lower.