### PR TITLE
Update dependencies

### DIFF
--- a/aero-mavlink-router/aero-mavlink-router_1.0/debian/changelog
+++ b/aero-mavlink-router/aero-mavlink-router_1.0/debian/changelog
@@ -1,3 +1,9 @@
+mavlink-router (1.0-4) xenial; urgency=medium
+
+  * Update dependency list
+
+ -- Anselmo L. S. Melo <anselmo.melo@intel.com>  Wed, 15 Nov 2017 23:10:46 +0000
+
 mavlink-router (1.0-3) xenial; urgency=medium
 
   * Fix linter issues

--- a/aero-mavlink-router/aero-mavlink-router_1.0/debian/control
+++ b/aero-mavlink-router/aero-mavlink-router_1.0/debian/control
@@ -2,12 +2,12 @@ Source: mavlink-router
 Section: net
 Priority: optional
 Maintainer: Daniel E Ruano <daniel.e.ruano@intel.com>
-Build-Depends: debhelper (>=9), dh-systemd (>= 1.5), dh-autoreconf, python-pip, git
+Build-Depends: debhelper (>=9), dh-systemd (>= 1.5), dh-autoreconf, python-pip, git, python-future
 Standards-Version: 3.9.7
 Homepage: https://github.com/01org/mavlink-router
 
 Package: aero-mavlink-router
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, python-future
+Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: routes MAVLink packets
  mavlink-router moves MAVLink packets between network and physical interfaces.

--- a/aero-spi-xfer/aero-spi-xfer-0.1/debian/changelog
+++ b/aero-spi-xfer/aero-spi-xfer-0.1/debian/changelog
@@ -1,3 +1,9 @@
+aero-spi-xfer (0.1-4) xenial; urgency=medium
+
+  * Fix dependency list
+
+ -- Anselmo L. S. Melo <anselmo.melo@intel.com>  Wed, 15 Nov 2017 23:12:51 +0000
+
 aero-spi-xfer (0.1-3) xenial; urgency=medium
 
   * Fix linter issues

--- a/aero-spi-xfer/aero-spi-xfer-0.1/debian/control
+++ b/aero-spi-xfer/aero-spi-xfer-0.1/debian/control
@@ -8,6 +8,6 @@ Homepage: https://github.com/intel-aero/meta-intel-aero-base/tree/master/recipes
 
 Package: aero-spi-xfer
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, linux-headers-4.4.76-aero-1.2
+Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: SPI data transfer for Intel Aero
  SPI communication for Intel Aero.


### PR DESCRIPTION
mavlink-router: Move python-future to Build-Depends
spi-xfer: remove kernel headers from dependencies.