### PR TITLE
Remove python-pip from Build-Depends

### DIFF
--- a/aero-mavlink-router/aero-mavlink-router_1.0/debian/changelog
+++ b/aero-mavlink-router/aero-mavlink-router_1.0/debian/changelog
@@ -1,3 +1,9 @@
+mavlink-router (1.0-5) xenial; urgency=medium
+
+  * Remove python-pip from Build-Depends
+
+ -- Ritul Jasuja<ritul.jasuja@intel.com>  Tue, 21 Nov 2017 11:18:55 +0530
+
 mavlink-router (1.0-4) xenial; urgency=medium
 
   * Update dependency list

--- a/aero-mavlink-router/aero-mavlink-router_1.0/debian/control
+++ b/aero-mavlink-router/aero-mavlink-router_1.0/debian/control
@@ -2,7 +2,7 @@ Source: mavlink-router
 Section: net
 Priority: optional
 Maintainer: Daniel E Ruano <daniel.e.ruano@intel.com>
-Build-Depends: debhelper (>=9), dh-systemd (>= 1.5), dh-autoreconf, python-pip, git, python-future
+Build-Depends: debhelper (>=9), dh-systemd (>= 1.5), dh-autoreconf, git, python-future
 Standards-Version: 3.9.7
 Homepage: https://github.com/01org/mavlink-router
 


### PR DESCRIPTION
aero-mavlink-router package fails for `unmet dependency on python-pip`
python-pip package is not required