### PR TITLE
Update network-manager setup to change default mode

### DIFF
--- a/aero-systemd/debian/changelog
+++ b/aero-systemd/debian/changelog
@@ -1,3 +1,9 @@
+aero-systemd (0.1-6) xenial; urgency=medium
+
+  * Update firstboot-networkmanager-setup to change default mode to managed
+
+ -- Avinash Reddy Palleti <avinash.reddy.palleti@intel.com>  Wed, 03 Jan 2018 11:33:40 +0530
+
 aero-systemd (0.1-5) xenial; urgency=medium
 
   * Bump pkg version

--- a/aero-systemd/debian/patches/default-managed-mode.patch
+++ b/aero-systemd/debian/patches/default-managed-mode.patch
@@ -1,0 +1,18 @@
+Index: aero-systemd-0.1/firstboot-networkmanager-setup
+===================================================================
+--- aero-systemd-0.1.orig/firstboot-networkmanager-setup
++++ aero-systemd-0.1/firstboot-networkmanager-setup
+@@ -36,12 +36,11 @@ systemctl stop dnsmasq || /bin/true
+ rm /etc/NetworkManager/system-connections/* || /bin/true
+ 
+ # Wifi
+-nmcli con add type wifi ifname '*' con-name hotspot autoconnect yes ssid $SSID
++nmcli con add type wifi ifname '*' con-name hotspot ssid $SSID
+ nmcli con modify hotspot 802-11-wireless.mode ap 802-11-wireless.band bg ipv4.method shared
+ nmcli con modify hotspot wifi-sec.key-mgmt wpa-psk
+ nmcli con modify hotspot wifi-sec.psk "$WIFI_AP_DEFAULTPASSWORD"
+ nmcli con modify hotspot ipv4.addresses 192.168.8.1/24
+-nmcli con up hotspot
+ 
+ # Modem
+ nmcli con add type gsm ifname '*' con-name modem autoconnect yes apn $MODEM_APN_NAME

--- a/aero-systemd/debian/patches/series
+++ b/aero-systemd/debian/patches/series
@@ -1,3 +1,4 @@
 firstboot-disable-dnsmasq.patch
 firstboot-keep-resolv-conf.patch
 firstboot-modem-apn.patch
+default-managed-mode.patch


### PR DESCRIPTION
Updating firstboot-networkmanager-setup to change default mode from AP to
managed.